### PR TITLE
Add previewSecs to additionalMetadata

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cacophony-processing (0.5.0) xenial; urgency=medium
+
+  * 0.5.0 release
+
+ -- Menno Finlay-Smits <menno@localhost>  Fri, 30 Nov 2018 14:48:06 +1300
+
 cacophony-processing (0.4.0) xenial; urgency=medium
 
   * 0.4.0 release

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3~=1.4.7
 PyYAML~=3.12
 requests~=2.20.0
-cptv
+cptv~=0.3.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Project API, performing post-upload processing tasks.
 
 setuptools.setup(
     name="cacophony-processing",
-    version="0.4.0",
+    version="0.5.0",
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,
     maintainer=AUTHOR,

--- a/thermal_processing.py
+++ b/thermal_processing.py
@@ -126,15 +126,20 @@ def one_candidate(candidates):
 def replace_ext(filename, ext):
     return filename.parent / (filename.stem + ext)
 
+
 def update_metadata(recording, api):
     with open(str(recording["filename"]), "rb") as f:
         reader = CPTVReader(f)
         metadata = {}
         metadata["recordingDateTime"] = reader.timestamp.isoformat()
+
         # TODO Add device name when it can be processed on api server
         # metadata["device_name"] = reader.device_name
 
-        count = 0.0
+        if reader.preview_secs:
+            metadata["additionalMetadata"] = {"previewSecs": reader.preview_secs}
+
+        count = 0
         for _ in reader:
             count += 1
         metadata["duration"] = round(count / FRAME_RATE)
@@ -158,7 +163,7 @@ def main():
 
                     update_metadata(recording, api)
 
-                    if (conf.do_classify):
+                    if conf.do_classify:
                         classify(recording, api, s3)
             else:
                 time.sleep(SLEEP_SECS)


### PR DESCRIPTION
* Depend on cptv >= 0.3.0 to pull in support for CPTV v2 format
* When the preview secs field is available in the CPTV file, add it to the recording's additionalMetadata field
* Bump the version number to 0.5.0