### PR TITLE
Minor fixes

### DIFF
--- a/_release/postinstall.sh
+++ b/_release/postinstall.sh
@@ -6,7 +6,8 @@ username=cacophony-processing
 id $username &> /dev/null || useradd --system \
                                      --user-group \
                                      --groups docker \
-                                     --home /usr/bin \
+                                     --home-dir /var/cache/$username \
+                                     --create-home \
                                      --shell /usr/sbin/nologin \
                                      $username
 

--- a/main.py
+++ b/main.py
@@ -104,9 +104,11 @@ class Processor:
                 del self.in_progress[recording_id]
                 err = future.exception()
                 if err:
-                    logger.error(
-                        f"{self.recording_type}.{self.processing_state} processing of {recording_id} failed: {err}:\n{err.traceback}"
-                    )
+                    msg = f"{self.recording_type}.{self.processing_state} processing of {recording_id} failed: {err}"
+                    tb = getattr(err, "traceback", None)
+                    if tb:
+                        msg += f":\n{tb}"
+                    logger.error(msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- cacophony-processing user account must have a real home directory
- don't assume exception returned by a future will have a traceback attached