### PR TITLE
Context manager which includes output on CalledProcessError

### DIFF
--- a/processing/processutils.py
+++ b/processing/processutils.py
@@ -1,0 +1,39 @@
+from subprocess import CalledProcessError
+
+
+class HandleCalledProcessError:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, err_type, err, _):
+        if err_type is not CalledProcessError:
+            return False
+
+        new_err = CalledProcessErrorWithOutput(
+            err.returncode, err.cmd, output=err.output, stderr=err.stderr
+        )
+        new_err.__suppress_context__ = True
+        raise new_err
+
+
+class CalledProcessErrorWithOutput(CalledProcessError):
+    def __str__(self):
+        msg = super().__str__()
+
+        stdout = decode(self.stdout)
+        if stdout:
+            msg += "\n" + stdout
+
+        stderr = decode(self.stderr)
+        if stderr:
+            msg += "\n" + stderr
+
+        return msg
+
+
+def decode(v):
+    if not v:
+        return None
+    elif isinstance(v, bytes):
+        return v.decode("utf-8")
+    return v

--- a/tests/processutils_test.py
+++ b/tests/processutils_test.py
@@ -1,0 +1,62 @@
+from subprocess import CalledProcessError
+from pytest import raises
+from processing.processutils import (
+    HandleCalledProcessError,
+    CalledProcessErrorWithOutput,
+)
+
+
+def test_no_error():
+    with HandleCalledProcessError():
+        x = 1
+
+
+def test_error():
+    with raises(
+        CalledProcessErrorWithOutput,
+        match="Command 'cmd' returned non-zero exit status 99.$",
+    ):
+        with HandleCalledProcessError():
+            raise CalledProcessError(99, "cmd")
+
+
+def test_error_stdout():
+    with raises(
+        CalledProcessErrorWithOutput,
+        match="Command 'cmd' returned non-zero exit status 99.\nout$",
+    ):
+        with HandleCalledProcessError():
+            raise CalledProcessError(99, "cmd", output="out")
+
+
+def test_error_stderr():
+    with raises(
+        CalledProcessErrorWithOutput,
+        match="Command 'cmd' returned non-zero exit status 99.\nerr$",
+    ):
+        with HandleCalledProcessError():
+            raise CalledProcessError(99, "cmd", stderr="err")
+
+
+def test_error_stdout_stderr():
+    with raises(
+        CalledProcessErrorWithOutput,
+        match="Command 'cmd' returned non-zero exit status 99.\nout\nerr$",
+    ):
+        with HandleCalledProcessError():
+            raise CalledProcessError(99, "cmd", output="out", stderr="err")
+
+
+def test_error_bytes():
+    with raises(
+        CalledProcessErrorWithOutput,
+        match="Command 'cmd' returned non-zero exit status 99.\nout\nerr$",
+    ):
+        with HandleCalledProcessError():
+            raise CalledProcessError(99, "cmd", output=b"out", stderr=b"err")
+
+
+def test_other_error():
+    with raises(ValueError, match="foo"):
+        with HandleCalledProcessError():
+            raise ValueError("foo")


### PR DESCRIPTION
This makes using subprocess more convenient and helps diagnose failing external commands.

We are seeing the thermal classify comand occasionally fail but are missing the command output. This PR will fix that.