### PR TITLE
update cptv version, amd skip background frames in duration count

### DIFF
--- a/processing/thermal.py
+++ b/processing/thermal.py
@@ -168,7 +168,9 @@ def update_metadata(conf, recording, api):
             metadata["additionalMetadata"] = {"previewSecs": reader.preview_secs}
 
         count = 0
-        for _ in reader:
+        for frame in reader:
+            if frame.background_frame:
+                continue
             count += 1
         metadata["duration"] = round(count / FRAME_RATE)
         recording["duration"] = metadata["duration"]
@@ -221,7 +223,7 @@ def use_tag(model, prediction, wallaby_device):
 
 
 def get_master_tag(model_results, wallaby_device=False):
-    """ Choose a tag to be the overriding tag for this track """
+    """Choose a tag to be the overriding tag for this track"""
     valid_results = [
         (model, prediction)
         for model, prediction in model_results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3~=1.4.7
 PyYAML~=4.2b4
 requests~=2.20.0
-cptv~=1.3.0
+cptv~=1.5.0
 librosa~=0.6.2
 setuptools~=40.6.2
 Pebble~=4.4.0


### PR DESCRIPTION
This will generally make all newer recordings 1/9 of a second shorter (As there is 1 background frame)